### PR TITLE
Add dtype to matrix and vector (closes #25)

### DIFF
--- a/findiff/coefs.py
+++ b/findiff/coefs.py
@@ -125,7 +125,7 @@ def _build_matrix(p, q, deriv):
     A = [([1 for _ in range(-p, q+1)])]
     for i in range(1, p + q + 1):
         A.append([j**i for j in range(-p, q+1)])
-    return np.array(A)
+    return np.array(A,dtype='float')
 
 
 def _build_rhs(p, q, deriv):
@@ -133,7 +133,7 @@ def _build_rhs(p, q, deriv):
 
     b = [0 for _ in range(p+q+1)]
     b[deriv] = math.factorial(deriv)
-    return np.array(b)
+    return np.array(b,dtype='float')
 
 
 def _build_matrix_non_uniform(p, q, coords, k):
@@ -142,4 +142,4 @@ def _build_matrix_non_uniform(p, q, coords, k):
     for i in range(1, p + q + 1):
         line = [(coords[k+j] - coords[k])**i for j in range(-p, q+1)]
         A.append(line)
-    return np.array(A)
+    return np.array(A,dtype='float')


### PR DESCRIPTION
With these changes the higher accuracy works 

```
ython 3.8.3 (default, May 15 2020, 00:00:00) 
[GCC 10.1.1 20200507 (Red Hat 10.1.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import findiff
>>> coefs = findiff.coefficients(deriv=1, acc=15)
>>> coefs
{'center': {'coefficients': array([ 9.71250971e-06, -1.77600178e-04,  1.55400155e-03, -8.70240870e-03,
        3.53535353e-02, -1.13131313e-01,  3.11111111e-01, -8.88888889e-01,
       -3.35961124e-10,  8.88888889e-01, -3.11111111e-01,  1.13131313e-01,
       -3.53535354e-02,  8.70240870e-03, -1.55400155e-03,  1.77600178e-04,
       -9.71250971e-06]), 'offsets': array([-8, -7, -6, -5, -4, -3, -2, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8])}, 'forward': {'coefficients': array([-3.13521989e+00,  1.23812179e+01, -3.58205673e+01,  8.69500474e+01,
       -1.67677472e+02,  2.57681506e+02, -3.17608486e+02,  3.15015193e+02,
       -2.51170987e+02,  1.60051983e+02, -8.05591687e+01,  3.14080358e+01,
       -9.19335226e+00,  1.91993904e+00, -2.61530883e-01,  1.93028986e-02,
       -4.40848608e-04]), 'offsets': array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16])}, 'backward': {'coefficients': array([ 6.25000664e-02, -1.06666777e+00,  8.57143716e+00, -4.30769648e+01,
        1.51666808e+02, -3.97091263e+02,  8.00800679e+02, -1.27111213e+03,
        1.60875120e+03, -1.63428683e+03,  1.33466749e+03, -8.73600475e+02,
        4.55000209e+02, -1.86666735e+02,  6.00000154e+01, -1.60000022e+01,
        3.38072914e+00]), 'offsets': array([-16, -15, -14, -13, -12, -11, -10,  -9,  -8,  -7,  -6,  -5,  -4,
        -3,  -2,  -1,   0])}}
>>> coefs["center"]
{'coefficients': array([ 9.71250971e-06, -1.77600178e-04,  1.55400155e-03, -8.70240870e-03,
        3.53535353e-02, -1.13131313e-01,  3.11111111e-01, -8.88888889e-01,
       -3.35961124e-10,  8.88888889e-01, -3.11111111e-01,  1.13131313e-01,
       -3.53535354e-02,  8.70240870e-03, -1.55400155e-03,  1.77600178e-04,
       -9.71250971e-06]), 'offsets': array([-8, -7, -6, -5, -4, -3, -2, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8])}
>>> coefs = findiff.coefficients(deriv=1, acc=16)
>>> coefs["center"]
{'coefficients': array([ 9.71250971e-06, -1.77600178e-04,  1.55400155e-03, -8.70240870e-03,
        3.53535353e-02, -1.13131313e-01,  3.11111111e-01, -8.88888889e-01,
       -3.35961124e-10,  8.88888889e-01, -3.11111111e-01,  1.13131313e-01,
       -3.53535354e-02,  8.70240870e-03, -1.55400155e-03,  1.77600178e-04,
       -9.71250971e-06]), 'offsets': array([-8, -7, -6, -5, -4, -3, -2, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8])}
```
