### PR TITLE
exclude tests from setup.py for conda forge compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup(
     version=version,
     description='A Python package for finite difference derivatives in any number of dimensions.',
     long_description="""A Python package for finite difference derivatives in any number of dimensions.
-    
-    Features: 
+
+    Features:
 
         * Differentiate arrays of any number of dimensions along any axis
         * Partial derivatives of any desired order
@@ -52,7 +52,7 @@ setup(
         'Programming Language :: Python :: 3.9',
     ],
     keywords=['finite-differences',  'numerical-derivatives', 'scientific-computing'],
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
     package_dir={name: name},
     include_package_data=True,
     install_requires=['numpy', 'scipy', 'sympy'],


### PR DESCRIPTION
In the interest of [getting the `findiff` package on the conda-forge platform](https://github.com/conda-forge/staged-recipes/pull/14582), this change should be made to the setup.py file. 

We have two options for how to handle this:
1. Create a new release of `findiff` with the changes of this pull request.
2. Add a patch to the official `findiff` source (PyPI) according to [these instructions](https://conda.io/projects/conda-build/en/latest/resources/define-metadata.html#patches).