### PR TITLE
Fix SyntaxWarning: invalid escape sequence '\p'

### DIFF
--- a/findiff/operators.py
+++ b/findiff/operators.py
@@ -4,7 +4,7 @@ from .stencils import StencilSet
 
 
 class FinDiff(LinearMap):
-    """ A representation of a general linear differential operator expressed in finite differences.
+    r""" A representation of a general linear differential operator expressed in finite differences.
 
             FinDiff objects can be added with other FinDiff objects. They can be multiplied by
             objects of type Coefficient.


### PR DESCRIPTION
Hi, with python 3.12, the first import throw a warning like [this](https://stackoverflow.com/questions/52335970/how-to-fix-syntaxwarning-invalid-escape-sequence-in-python). Now is fixed with this change.

```console
$ ipython
Python 3.12.6 (main, Sep  8 2024, 13:18:56) [GCC 14.2.1 20240805]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from findiff import FinDiff
/usr/lib/python3.12/site-packages/findiff/operators.py:7: SyntaxWarning: invalid escape sequence '\p'
  """ A representation of a general linear differential operator expressed in finite differences.
```