### PR TITLE
Fix some broken tests (and improve developer experience)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,11 +2,20 @@ name: Checks
 
 on:
   push:
+    branches: [main, master]
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: test-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONUNBUFFERED: "1"
+  FORCE_COLOR: "1"
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -21,18 +30,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          # prerequisites
-          python -m pip install --upgrade pip wheel
-          python -m pip install codecov coverage pytest pytest-cov
-          # install dependencies
-          pip install -e .[all]
-          # show installed packages
-          pip freeze
+          python -m pip install --upgrade pip
+          python -m pip install pytest pytest-cov
+      - name: Install package
+        run: pip install -e .
+      - name: Show installed packages
+        run: pip freeze
       - name: Test with pytest
-        run: |
-          pytest
+        run: pytest --cov --showlocals
       - name: Submit code coverage
-        run: |
-          pytest --cov=findiff --cov-report=html tests        
-          codecov -t ${{ secrets.CODECOV_TOKEN }}
-
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,16 @@ report.exclude_lines = [
     "@overload",
     "@unittest.skip",
 ]
+
+[tool.tox]
+requires = ["tox>=4.19"]
+env_list = ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
+
+[tool.tox.env_run_base]
+wheel_build_env = ".pkg"
+deps = [
+    "pytest",
+]
+commands = [
+    ["pytest"],
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,15 @@ include = ["findiff"]
 
 [tool.setuptools.dynamic]
 version = { attr = "findiff.__version__" }
+
+[tool.coverage]
+run.source_pkgs = ["findiff", "tests"]
+run.branch = true
+run.parallel = true
+report.exclude_lines = [
+    "no cov",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "@overload",
+    "@unittest.skip",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,11 @@ report.exclude_lines = [
 ]
 
 [tool.tox]
-requires = ["tox>=4.19"]
-env_list = ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
+requires = ["tox>=4.21"]
+env_list = [
+    "fmt", "lint",
+    "3.13", "3.12", "3.11", "3.10", "3.9", "3.8",
+]
 
 [tool.tox.env_run_base]
 wheel_build_env = ".pkg"
@@ -70,4 +73,33 @@ deps = [
 ]
 commands = [
     ["pytest"],
+]
+
+[tool.tox.env.fmt]
+package = "skip"
+deps = [
+    "ruff",
+]
+commands = [
+    ["ruff", "format", "--check", { replace = "posargs", default = ["."], extend = true }],
+]
+
+[tool.tox.env.lint]
+package = "skip"
+deps = [
+    "ruff",
+]
+commands = [
+    ["ruff", "check", "--no-fix", { replace = "posargs", default = ["."], extend = true }],
+]
+
+[tool.ruff]
+line-length = 88
+lint.extend-select = [
+    "B",  # flake8-bugbear
+    "I",  # isort
+    "UP",  # pyupgrade
+]
+extend-exclude = [
+    "docs/source/**/*.ipynb",
 ]

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -10,7 +10,7 @@ class TestOldBugs(unittest.TestCase):
 
     def test_findiff_should_raise_exception_when_applied_to_unevaluated_function(self):
         def f(x, y):
-            return 5 * x**2 - 5 * x + 10 * y**2 - 10 * y
+            return 5 * x**2 - 5 * x + 10 * y**2 - 10 * y  # pragma: no cover
 
         d_dx = FinDiff(1, 0.01)
         self.assertRaises(ValueError, lambda ff: d_dx(ff), f)
@@ -128,12 +128,14 @@ class TestOldBugs(unittest.TestCase):
 
         np.testing.assert_allclose(d_dx(np.linspace(0, 1, 11)), np.ones(11))
 
-    def assert_dict_almost_equal(self, actual, expected, places=7):
-        if len(actual) != len(expected):
-            return False
-
-        for key, value in actual.items():
-            self.assertAlmostEqual(actual[key], expected[key], places=places)
+    def assert_dict_almost_equal(self, first, second, places=7):
+        for k in set(first) & set(second):
+            self.assertAlmostEqual(first[k], second[k], places=places)
+        # NOTE: missing item(s) should be zero
+        for k in set(first) - set(second):
+            self.assertAlmostEqual(first[k], 0, places=places)
+        for k in set(second) - set(first):
+            self.assertAlmostEqual(0, second[k], places=places)
 
 
 if __name__ == "__main__":

--- a/tests/test_coefs.py
+++ b/tests/test_coefs.py
@@ -138,7 +138,7 @@ class TestCoefs(unittest.TestCase):
             with self.subTest():
                 self.assertEqual(2, coefs["accuracy"])
 
-    def test_calc_accuracy_from_offsets_symbolic(self):
+    def test_calc_accuracy_from_offsets_symbolic1(self):
         for analytic_inv in [True, False]:
             coefs = calc_coefs(
                 2, [0, 1, 2, 3], symbolic=True, analytic_inv=analytic_inv
@@ -146,7 +146,7 @@ class TestCoefs(unittest.TestCase):
             with self.subTest():
                 self.assertEqual(2, coefs["accuracy"])
 
-    def test_calc_accuracy_from_offsets_symbolic(self):
+    def test_calc_accuracy_from_offsets_symbolic2(self):
         for analytic_inv in [True, False]:
             coefs = calc_coefs(
                 2, [-4, -2, 0, 2, 4], symbolic=True, analytic_inv=analytic_inv

--- a/tests/test_findiff.py
+++ b/tests/test_findiff.py
@@ -287,13 +287,6 @@ class FinDiffTest(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(2 * np.ones_like(X), du_dx)
 
-    def dict_almost_equal(self, d1, d2):
-
-        self.assertEqual(len(d1), len(d2))
-
-        for k, v in d1.items():
-            self.assertAlmostEqual(v, d2[k])
-
     def test_matrix_1d(self):
 
         x = np.linspace(0, 6, 7)
@@ -509,6 +502,8 @@ class TestFinDiffNonUniform(unittest.TestCase):
             6 * np.ones_like(X).reshape(-1), mat.dot(u.reshape(-1))
         )
 
+    def test_grid(self):
+        np.testing.assert_equal(grid(2, 50, 0, 1), grid(2, [50, 50], [0, 0], [1, 1]))
 
 def grid(ndim, npts, a, b):
 
@@ -516,7 +511,7 @@ def grid(ndim, npts, a, b):
         a = [a] * ndim
     if not hasattr(b, "__len__"):
         b = [b] * ndim
-    if not hasattr(np, "__len__"):
+    if not hasattr(npts, "__len__"):
         npts = [npts] * ndim
 
     coords = [np.linspace(a[i], b[i], npts[i]) for i in range(ndim)]


### PR DESCRIPTION
Ruff claims some errors, but fixes are not included in this PR.

Additional information:
The number of stencil elements differs between windows and macos.
https://github.com/n-takumasa/findiff/actions/runs/12427590734/job/34697664219
```
tests/test_bugs.py:132: in assert_dict_almost_equal
    self.assertEqual(len(actual), len(expected))
E   AssertionError: 4 != 5
        actual     = {(-2, 0): 0.08333333333333333,
 (-1, 0): -0.6666666666666666,
 (1, 0): 0.6666666666666666,
 (2, 0): -0.08333333333333333}
        expected   = {(np.int64(-2), np.int64(0)): np.float64(0.08333333333333334),
 (np.int64(-1), np.int64(0)): np.float64(-0.6666666666666667),
 (np.int64(0), np.int64(0)): np.float64(2.379049338482478e-16),
 (np.int64(1), np.int64(0)): np.float64(0.6666666666666665),
 (np.int64(2), np.int64(0)): np.float64(-0.08333333333333333)}
        places     = 7
        self       = <tests.test_bugs.TestOldBugs testMethod=test_accuracy_should_be_passed_down_to_stencil>
=========================== short test summary info ============================
FAILED tests/test_bugs.py::TestOldBugs::test_accuracy_should_be_passed_down_to_stencil - AssertionError: 4 != 5
=================== 1 failed, 157 passed, 3 skipped in 1.75s ===================
Error: Process completed with exit code 1.
```
