### PR TITLE
Update examples

### DIFF
--- a/examples/examples-basic.ipynb
+++ b/examples/examples-basic.ipynb
@@ -81,14 +81,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d2_dx2 = Diff(0, dx, acc=2)"
+    "d2_dx2 = Diff(0, dx, acc=2)**2"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first parameter is the axis along which to take the derivative. Since we want to apply it to the one and only axis of the 1D array, this is a 0. The second parameter is the grid spacing, the third parameter the derivative order you want, in our case 2. If you want a first derivative, you can skip the third argument as it defaults to 1.\n",
+    "The first parameter is the axis along which to take the derivative. Since we want to apply it to the one and only axis of the 1D array, this is a 0. The second parameter is the grid spacing. The third parameter is the target accuracy. Last, we need to exponentiate the operator to the order we want, in our case 2.\n",
     "\n",
     "Then we apply the operator to f and g, respectively:"
    ]
@@ -116,7 +116,7 @@
    "source": [
     "#### Finite Difference Coefficients\n",
     "\n",
-    "By default the `FinDiff` class uses second order accuracy. For the second derivative, it uses the following finite difference coefficients:"
+    "By default the `Diff` class uses second order accuracy. For the second derivative, it uses the following finite difference coefficients:"
    ]
   },
   {
@@ -158,7 +158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But `FinDiff` can handle any accuracy order. For instance, have you ever wondered, what the 10th order accurate coefficients look like? Here they are:"
+    "But `Diff` can handle any accuracy order. For instance, have you ever wondered, what the 10th order accurate coefficients look like? Here they are:"
    ]
   },
   {
@@ -206,7 +206,7 @@
    "source": [
     "#### Accuracy order\n",
     "\n",
-    "If you want to use for example 10th order accuracy, just tell the `FinDiff` constructor to use it:"
+    "If you want to use for example 10th order accuracy, just tell the `Diff` constructor to use it:"
    ]
   },
   {
@@ -220,9 +220,7 @@
    },
    "outputs": [],
    "source": [
-    "from findiff import FinDiff\n",
-    "\n",
-    "d2_dx2 = FinDiff(0, dx, 2, acc=10)\n",
+    "d2_dx2 = Diff(0, dx, acc=10)**2\n",
     "result = d2_dx2(f)"
    ]
   },
@@ -269,8 +267,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d_dx = FinDiff(0, dx)\n",
-    "d_dz = FinDiff(2, dz)"
+    "d_dx = Diff(0, dx)\n",
+    "d_dz = Diff(2, dz)"
    ]
   },
   {
@@ -286,7 +284,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d3_dx2dy = FinDiff((0, dx, 2), (1, dy))\n",
+    "d3_dx2dy = Diff(0, dx)**2 * Diff(1, dy)\n",
     "result = d3_dx2dy(f)"
    ]
   },
@@ -303,7 +301,7 @@
    "source": [
     "## General Linear Differential Operators\n",
     "\n",
-    "`FinDiff` objects can bei added and easily multiplied by numbers. For example, to express\n",
+    "`Diff` objects can bei added and easily multiplied by numbers. For example, to express\n",
     "\n",
     "$$\n",
     "\\frac{\\partial^2}{\\partial x^2} + 2\\frac{\\partial^2}{\\partial x \\partial y} + \\frac{\\partial^2}{\\partial y^2} =\n",
@@ -324,7 +322,7 @@
    },
    "outputs": [],
    "source": [
-    "linear_op = FinDiff(0, dx, 2) + 2 * FinDiff((0, dx), (1, dy)) + FinDiff(1, dy, 2)"
+    "linear_op = Diff(0, dx)**2 + 2 * Diff(0, dx) * Diff(1, dy) + Diff(1, dy)**2"
    ]
   },
   {
@@ -350,7 +348,7 @@
    "source": [
     "from findiff import Coefficient\n",
     "\n",
-    "linear_op = Coefficient(X) * FinDiff(0, dx) + Coefficient(Y**2) * FinDiff(1, dy)"
+    "linear_op = Coefficient(X) * Diff(0, dx) + Coefficient(Y**2) * Diff(1, dy)"
    ]
   },
   {

--- a/examples/examples-basic.ipynb
+++ b/examples/examples-basic.ipynb
@@ -301,7 +301,7 @@
    "source": [
     "## General Linear Differential Operators\n",
     "\n",
-    "`Diff` objects can bei added and easily multiplied by numbers. For example, to express\n",
+    "`Diff` objects can be added and easily multiplied by numbers. For example, to express\n",
     "\n",
     "$$\n",
     "\\frac{\\partial^2}{\\partial x^2} + 2\\frac{\\partial^2}{\\partial x \\partial y} + \\frac{\\partial^2}{\\partial y^2} =\n",

--- a/examples/examples-non-uniform-grids.ipynb
+++ b/examples/examples-non-uniform-grids.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "%matplotlib inline\n",
     "import numpy as np\n",
-    "from findiff import FinDiff\n",
+    "from findiff import Diff\n",
     "import matplotlib.pyplot as plt"
    ]
   },
@@ -167,8 +167,8 @@
     "dx1 = x1[1] - x1[0]\n",
     "dx2 = x2[1] - x2[0]\n",
     "\n",
-    "d_dx1 = FinDiff(0, dx1, acc=2)\n",
-    "d_dx2 = FinDiff(0, dx2)\n",
+    "d_dx1 = Diff(0, dx1, acc=2)\n",
+    "d_dx2 = Diff(0, dx2)\n",
     "\n",
     "df_dx1 = d_dx1(f1)\n",
     "df_dx2 = d_dx2(f2)\n",
@@ -260,7 +260,7 @@
     }
    ],
    "source": [
-    "d_dx = FinDiff(0, x_nu, acc=2)\n",
+    "d_dx = Diff(0, x_nu, acc=2)\n",
     "df_dx_nu = d_dx(f_nu)\n",
     "\n",
     "plt.plot(x_fine, df_dx_exact)\n",

--- a/examples/examples-polar.ipynb
+++ b/examples/examples-polar.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from findiff import FinDiff, Coefficient, Laplacian"
+    "from findiff import Diff, Coefficient, Laplacian"
    ]
   },
   {
@@ -206,7 +206,7 @@
    },
    "outputs": [],
    "source": [
-    "laplace_polar = FinDiff(0, dr, 2) + Coefficient(1/R) * FinDiff(0, dr) + Coefficient(1/R**2) * FinDiff(1, dphi, 2)\n",
+    "laplace_polar = Diff(0, dr)**2 + Coefficient(1/R) * Diff(0, dr) + Coefficient(1/R**2) * Diff(1, dphi)**2\n",
     "result = laplace_polar(f_polar)"
    ]
   },


### PR DESCRIPTION
Hi ! Love the project, thanks for maintaining it.
Using FinDiff raises a DeprecationWarning, but it is present in several of the examples notebooks, which are otherwise very useful. I migrated the examples from FinDiff to Diff.