### PR TITLE
Fix flaky tolerance in batched non-uniform coefficients test

### DIFF
--- a/tests/test_nonuniform_optimized.py
+++ b/tests/test_nonuniform_optimized.py
@@ -10,7 +10,7 @@ Covers:
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_allclose, assert_array_almost_equal
 
 from findiff import Diff
 from findiff.coefs import (
@@ -81,7 +81,7 @@ class TestBatchedCoefficients:
             else:
                 j = i - result["num_bndry"]
                 actual = result["center"]["coefficients"][j]
-            assert_array_almost_equal(actual, expected["coefficients"], decimal=10)
+            assert_allclose(actual, expected["coefficients"], rtol=1e-12, atol=1e-12)
 
     def test_batched_result_structure(self):
         """Result dict has the expected keys and array shapes."""


### PR DESCRIPTION
## Summary

`tests/test_nonuniform_optimized.py::TestBatchedCoefficients::test_batched_various_deriv_acc[4-3]` fails deterministically on Python 3.12 / Ubuntu CI (visible on PR #105 and any PR run against current `master`). The root cause is a tolerance-too-tight assertion, not a real numerical regression.

The test calls

```python
assert_array_almost_equal(actual, expected["coefficients"], decimal=10)
```

which is an **absolute** tolerance of ~1.5e-10. For the `acc=4`, `deriv=3` case, two of seven coefficients are O(5e4):

```
ACTUAL:  -40961.3453155986
DESIRED: -40961.345315598395
```

The batched and per-point implementations agree to ~2.7e-10 absolute, ~5e-15 relative — i.e. machine epsilon. So the test fails on absolute tolerance even though the two implementations are numerically identical to all the precision a `float64` can provide.

## Fix

Switch to `np.testing.assert_allclose(rtol=1e-12, atol=1e-12)`, which is scale-aware and matches the actual agreement between the two implementations. `rtol=1e-12` is still ~1000× stricter than the standard library default and is well above machine epsilon, so it preserves the original intent (verify the batched path is essentially bit-equivalent to the per-point path) without being fooled by coefficient magnitude.

## Test plan

- [x] `pytest tests/test_nonuniform_optimized.py::TestBatchedCoefficients::test_batched_various_deriv_acc -v` → 6 passed (was 5 passed, 1 failed).
- [x] `pytest -q` → 407 passed, 30 skipped, 0 failed.
- [ ] CI green on all matrix entries (Python 3.11 / 3.12 / 3.13 × Ubuntu / macOS / Windows).