### PR TITLE
Fix JAX 0-d array spacing crash in make_axis

### DIFF
--- a/findiff/grids.py
+++ b/findiff/grids.py
@@ -83,4 +83,7 @@ def make_axis(dim, config_or_axis, periodic=False):
     if isinstance(config_or_axis, numbers.Number):
         return EquidistantAxis(dim, spacing=config_or_axis, periodic=periodic)
     elif is_array(config_or_axis):
-        return NonEquidistantAxis(dim, coords=np.asarray(config_or_axis), periodic=periodic)
+        coords = np.asarray(config_or_axis)
+        if coords.ndim == 0:
+            return EquidistantAxis(dim, spacing=float(coords), periodic=periodic)
+        return NonEquidistantAxis(dim, coords=coords, periodic=periodic) 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -393,6 +393,17 @@ class TestJAXBackend:
         assert self._is_jax(result)
         assert_array_almost_equal(np.asarray(result), np.cos(x), decimal=2)
 
+    def test_jax_scalar_spacing(self):
+        x = self.jnp.linspace(0, 2 * np.pi, 1000)
+        dx = x[1] - x[0]
+        assert dx.ndim == 0
+        f = self.jnp.sin(x)
+        result = Diff(0, dx)(f)
+        assert self._is_jax(result)
+        assert_array_almost_equal(
+            np.asarray(result), np.cos(np.asarray(x)), decimal=3
+        )
+
 
 # ---------------------------------------------------------------------------
 # CuPy backend tests (skipped when CuPy is not installed)


### PR DESCRIPTION
The first snippet in the GPU / JAX Support section of the README crashes:
  
      x  = jnp.linspace(0, 2 * jnp.pi, 1000)
      dx = x[1] - x[0]
      Diff(0, dx)(jnp.sin(x))    # TypeError: len() of unsized object
      
  `dx` is a JAX 0-d array, which isn't a `numbers.Number`, so `make_axis` routes
  it to the non-uniform path and `len(coords)` fails. Same crash applies to numpy
  and CuPy 0-d arrays.
  
  Fix: in the `is_array` branch, treat `ndim == 0` as scalar spacing. Regression
  test added under `TestJAXBackend`.